### PR TITLE
Feat7/refresh

### DIFF
--- a/authorization/jwt.js
+++ b/authorization/jwt.js
@@ -39,7 +39,7 @@ function verifyRefreshToken(token) {
 function verifyTokenMiddleware(req, res, next) {
   const authHeader = req.headers.authorization;
   if (!authHeader) {
-    return res.status(403).json({ message: "Authorization header is missing" });
+    return res.status(403).json({ message: "인증 권한 헤더가 없음" });
   }
   const token = authHeader.split("Bearer ")[1]; // header에서 access token을 가져옵니다.
   if (!token) {

--- a/authorization/jwt.js
+++ b/authorization/jwt.js
@@ -8,7 +8,7 @@ const refreshSecretKey = process.env.JWT_REFRESH_SECRET;
 
 //토큰 생성 함수
 function generateToken(payload) {
-  return jwt.sign(payload, secretKey, { expiresIn: "1800s" });
+  return jwt.sign(payload, secretKey, { expiresIn: "30s" });
 }
 
 //리프레쉬 토큰 생성 함수

--- a/authorization/jwt.js
+++ b/authorization/jwt.js
@@ -8,7 +8,7 @@ const refreshSecretKey = process.env.JWT_REFRESH_SECRET;
 
 //토큰 생성 함수
 function generateToken(payload) {
-  return jwt.sign(payload, secretKey, { expiresIn: "30s" });
+  return jwt.sign(payload, secretKey, { expiresIn: "1800s" });
 }
 
 //리프레쉬 토큰 생성 함수

--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -134,7 +134,7 @@ const deleteUser = async (req, res) => {
 };
 
 const refreshToken = async (req, res) => {
-  const { refreshToken, userId } = req.body;
+  const { refreshToken, user_id } = req.body;
   if (!refreshToken) {
     return res.status(403).json({ message: "리프레쉬 토큰이 없습니다." });
   }
@@ -145,7 +145,7 @@ const refreshToken = async (req, res) => {
   }
   const decoded = verifyRefreshToken(refreshToken);
   if (decoded) {
-    const accesstoken = generateToken({ user_id: userId });
+    const accesstoken = generateToken({ user_id: user_id });
     return res.json({ accesstoken: accesstoken });
   } else {
     return res.status(403).json("리프레쉬 토큰 검증 실패");

--- a/router/auth.router.js
+++ b/router/auth.router.js
@@ -109,9 +109,9 @@ router.delete("/delete", verifyTokenMiddleware, authController.deleteUser);
  *             type: object
  *             properties:
  *               user_id:
- *                  type: string
- *                  example: "ktb23"
- *                  description: 아이디
+ *                  type: integer
+ *                  example: 1
+ *                  description: 유저 아이디
  *               refreshToken:
  *                 type: string
  *                 description: 리프레시 토큰

--- a/services/auth.service.js
+++ b/services/auth.service.js
@@ -124,6 +124,7 @@ const login = async (id, password, result) => {
     const refreshtoken = generateRefreshToken({ user_id: user.user_id });
 
     result(null, {
+      user_id: user.user_id,
       nickname: user.nickname,
       weight: user.weight,
       accesstoken: accesstoken,


### PR DESCRIPTION


## PR 유형

어떤 종류의 변경 사항인가요? (해당 사항에 모두 체크)

- [x] 버그 수정 (기존 문제를 수정)
- [ ] 기능 추가 (새로운 기능)
- [ ] 코드 스타일 수정 (포맷팅, 세미콜론 수정 등, 논리적 변경 없음)
- [ ] 리팩토링 (기능 수정 없이 코드 리팩토링)
- [ ] 문서 수정 (문서 추가 또는 수정)
- [ ] 테스트 추가 (기존 코드에 대한 테스트 추가)
- [ ] 빌드 또는 CI 관련 변경 사항

## PR 설명

### 현재 동작:

현재 애플리케이션에서는 리프레시 토큰 만료 시, 새 액세스 토큰을 발급받는 과정에서 user_id를 잘못된 방식으로 처리하고 있어, 인증이 제대로 이루어지지 않는 문제가 발생합니다.

### 새로운 동작:

이번 변경 후에는 user_id가 올바르게 처리되어, 리프레시 토큰이 만료된 후에도 새로운 액세스 토큰을 정상적으로 발급받고, 인증 절차가 원활하게 진행됩니다.

### 변경 이유:

인증 과정에서 발생하는 이 문제를 해결하여, 사용자들이 리프레시 토큰 만료 후에도 끊김 없이 애플리케이션을 사용할 수 있도록 하기 위함입니다. 이로 인해 보안 강화와 사용자 경험의 안정성을 확보할 수 있습니다.

### 버그 설명
발생한 버그:

리프레시 토큰이 만료되었을 때, 새로 발급받은 액세스 토큰이 user_id를 제대로 처리하지 않아 인증이 실패하는 문제가 있습니다. 이는 user_id를 회원 아이디로 잘못 인식하여 발생하는 오류입니다.
재현 방법:

리프레시 토큰이 만료된 상황에서 새 액세스 토큰을 요청합니다.
이 과정에서 user_id로 잘못된 검증이 이루어져, 인증이 실패합니다.
기대 결과:

로그인 시 올바른 user_id를 전달하고, 이후 인증 과정에서도 이를 정확히 검증하여, 토큰이 만료된 상황에서도 인증이 제대로 이루어져야 합니다.
## 이슈

## 버그 설명
발생한 버그에 대한 상세 설명을 작성해주세요.
user_id를 회원 아이디로 착각해서 리프레시 토큰으로 새로 발급 받으면 인증이 안되는 기능
## 재현 방법
1. 리프레시 토큰 만료
2. 새 액세스 토큰 받을 시
3. user_id로 검증

## 기대 결과
user_id를 로그인시 전달하고 
다시 검증 하면된다.

## 추가 정보
기타 참고할 사항이 있다면 작성해주세요.


#15 


